### PR TITLE
Command set description

### DIFF
--- a/docs/commands_draft.txt
+++ b/docs/commands_draft.txt
@@ -22,147 +22,73 @@ hashesdb about
 hashesdb schema
 	Prints schema documentation
 
-hashesdb create database_path [--overwrite]
+hashesdb create -d|--database DATABASE_PATH
+				[--overwrite]
+
 	Creates a hashesdb database at a given path
 
-hashesdb import import_file_path import_database_path [--overwrite]
+hashesdb import -f|--folder IMPORT_FOLDER_PATH
+				-d|--database IMPORT_DATABASE_PATH
+				-e|--extension IMPORT_FILE_FORMAT
+				[--overwrite]
+
 	Imports from a file to a database
 
-hashesdb export export_database_path export_file_path [--overwrite]
+hashesdb export -f|--folder EXPORT_FOLDER_PATH
+				-d|--database EXPORT_DATABASE_PATH
+				-e|--extension EXPORT_FILE_FORMAT
+				[--overwrite]
+
 	Exports from a database to a file
 
-hashesdb use database_path
+hashesdb use -d|--database DATABASE_PATH
 	Starts an interactive dialog (REPL) using the specified database
 
-hashesdb scan database_path [-t|--targets TARGETS_PARAMETERS]
-							[-c|--calculate HASH_FUNCTIONS]
-							[-d|--download DOWNLOAD_PATH]
-							[-r|--recursive]
-							[-j|--jobs N]
+hashesdb scan -d|--database DATABASE_PATH 	-t|--targets TARGETS_PARAMETERS
+											-c|--calculate HASH_FUNCTIONS
+											[-dw|--download DOWNLOAD_PATH]
+											[-r|--recursive]
+											[-j|--jobs N]
 
 	Calculates the hash values of the targets and inserts them in the database
 
-hashesdb search database_path [--hash HASH_VALUES]
-							  [-name|--filename FILENAMES]
-							  [-o|--output OUTPUT_PARAMETER]
-
-	Searches the database for files using one or more criteria.
-
-hashesdb sql database_path sql_query_string [-o|--output OUTPUT_PARAMETER]
-	Executes SQL query
-
-hashesdb dbinfo database_path
-	Prints information regarding the specified database.
-
-hashesdb stats database_path
-	Prints statistics regarding the specified database.
-
-hashesdb hash-functions database_path
-	Prints the hash functions available in the specified database.
-
-hashesdb hash-is-available hash_function_name database_path
-	Checks if a hash function is available in a specified database
-
-hashesdb search-duplicates database_path [-f|--file FILE_PATH_PARAM]
-	Searches for files with the same content as the given file
-
-hashesdb compare fuzzy_hash_function [-t|--targets TARGETS_PARAMETERS]
-									 [[-a|--all]|[-c|--comparsion-targets DIRECTORIES]]
-									 [-r|--recursive]
-									 [-d|--download DOWNLOAD_PATH]
-									 [-l|--limit THRESHOLD_VALUE]
-									 [-o|--output OUTPUT_PARAMETER]
-
-	Similarity comparsion.
-
-hashesdb swh ....
-	##TODO###
-
-		
-Commands inside the program's interactive dialog
---------------------------------------------------
-	help
-		This command will print all the availiable commands.
-
-	version:
-		This command will print the software's version (e.g. hashesdb 1.0.2).
-		
-	about:
-		This command will print basic information about the tool.
-
-	exit:
-		This command will terminate the program.
-
-	threads max_threads:
-		This command sets an upperbound regarding the threads the programm can use.
-
-	create database_path [--overwrite]:
-		This command will create a new database at a specified path.
-
-	use database_path:
-		This command will specify the database in which the user will work with.
-		The input will be a (relative or absolute) path to the .db file.
-		If the database does not exist, a new one will be created.
-
-	unuse:
-		This command will allow the user to stop using the database he is currently using.
-
-	status:
-		This command will print the database that is currently used.
-	
-	save:
-		This command will commit the last changes to the database.
-
-	rollback:
-		This command rolls back any changes to the database since the last call to "save".
-
-	clear:
-		This command will clear a database by deleting its content.		
-
-	dbinfo:
-		This command will print information about the used database.
-
-	stats:
-		Prints statistics about the used database.
-
-	schema
-		This command prints the database schema.
-
-	import import_file_path import_database_path [--overwrite]
-	Imports from a file to a database
-
-	export export_database_path export_file_path [--overwrite]
-	Exports from a database to a file
-		
-	scan [-t|--targets TARGETS_PARAMETERS] [-c|--calculate HASH_FUNCTIONS] [-d|--download DOWNLOAD_PATH] [-r|--recursive] [-j|--jobs N]
-	Calculates the hash values of the targets and inserts them in the database
-
-	search [--hash HASH_VALUES] [-name|--filename FILENAMES] [-o|--output OUTPUT_PARAMETER]
-	Searches the database for files using one or more criteria.
-
-	sql sql_query_string [-o|--output OUTPUT_PARAMETER]
-	Executes SQL query
-
-	hash_functions [--details]:
-		This command will print the available hash algorithms.
-		-details flag will print the whole hash_functions table
-
-	hash_is_available hash_function_name:
-		This command will return True if a hash function is available or False otherwise.
-
-	search-duplicates [-f|--file FILE_PATH_PARAM]
-	Searches for files with the same content as the given file
-
-	compare fuzzy_hash_function [-t|--targets TARGETS_PARAMETERS]
-								[[-a|--all]|[-c|--comparsion-targets DIRECTORIES]]
-								[-r|--recursive]
-								[-d|--download DOWNLOAD_PATH]
-								[-l|--limit THRESHOLD_VALUE]
+hashesdb search database_path 	 -d|--database DATABASE_PATH 
+								[--hash HASH_VALUES]
+								[--filename FILENAMES]
 								[-o|--output OUTPUT_PARAMETER]
 
+	Searches the database for files using one or more criteria.
+
+hashesdb sql 	 -d|--database DATABASE_PATH 
+				 -q|--query SQL_QUERY_STRING 
+				[-o|--output OUTPUT_PARAMETER]
+	Executes SQL query
+
+hashesdb dbinfo -d|--database DATABASE_PATH
+	Prints information regarding the specified database.
+
+hashesdb stats -d|--database DATABASE_PATH
+	Prints statistics regarding the specified database.
+
+hashesdb hash-functions -d|--database DATABASE_PATH
+	Prints the hash functions available in the specified database.
+
+hashesdb hash-is-available -d|--database DATABASE_PATH
+							-func|--hash_function_name HASH_FUNCTION NAME 
+	
+	Checks if a hash function is available in a specified database
+
+hashesdb search-duplicates -d|--database DATABASE_PATH
+						  [-f|--file FILE_PATH_PARAM]
+	Searches for files with the same content as the given file
+
+hashesdb compare 	 -d|--database DATABASE_PATH
+				     -fuzzy FUZZY_HASH_FUNCTION_NAME
+				    [-t|--targets TARGETS_PARAMETERS]
+					[[-a|--all]|[-c|--comparsion-targets DIRECTORIES]]
+					[-r|--recursive]
+					[-d|--download DOWNLOAD_PATH]
+					[-l|--limit THRESHOLD_VALUE]
+					[-o|--output OUTPUT_PARAMETER]
+
 	Similarity comparsion.
-
-
-	??
-	swh
-	??

--- a/docs/commands_draft.txt
+++ b/docs/commands_draft.txt
@@ -7,63 +7,82 @@ We will call a file containing such commands a "hdb script".
 
 Commands in the system's terminal
 ------------------------------------
-	hashesdb:
-		Starts an interactive dialog
-		
-	hashesdb help
+hashesdb
+	Starts an interactive dialog (REPL)
 
-	hashesdb help command
+hashesdb -h|--help
+	Prints help
 
-	hashesdb version
+hashesdb -v|--version
+	Prints tool's version
 
-	hashesdb about
+hashesdb about
+	Prints information about the project
 
-	hashesdb create database_path [--overwrite]
+hashesdb schema
+	Prints schema documentation
 
-	hashesdb -u database_path:
-		Starts an interactive dialog.
-		Sets the .db file located at the given path as the database we are currently using.
+hashesdb create database_path [--overwrite]
+	Creates a hashesdb database at a given path
 
-	hashesdb -u database_path dbinfo
+hashesdb import import_file_path import_database_path [--overwrite]
+	Imports from a file to a database
 
-	hashesdb -u database_path stats
+hashesdb export export_database_path export_file_path [--overwrite]
+	Exports from a database to a file
 
-	hashesdb schema
+hashesdb use database_path
+	Starts an interactive dialog (REPL) using the specified database
 
-	hashesdb import import_file_path import_file_format [--overwrite]
+hashesdb scan database_path [-t|--targets TARGETS_PARAMETERS]
+							[-c|--calculate HASH_FUNCTIONS]
+							[-d|--download DOWNLOAD_PATH]
+							[-r|--recursive]
+							[-j|--jobs N]
 
-	hashesdb export export_file_path file_format [--overwrite]
+	Calculates the hash values of the targets and inserts them in the database
 
-	hashesdb -u database_path execute_hdb_scipt hdb_script_path
+hashesdb search database_path [--hash HASH_VALUES]
+							  [-name|--filename FILENAMES]
+							  [-o|--output OUTPUT_PARAMETER]
 
-	hashesdb -u database_path scan -targets scan_targets -calc hash_functions_parameter	[-download download_location] [-r]
+	Searches the database for files using one or more criteria.
 
-	hashesdb scan_codes
+hashesdb sql database_path sql_query_string [-o|--output OUTPUT_PARAMETER]
+	Executes SQL query
 
-	hashesdb hash_functions [-details]
+hashesdb dbinfo database_path
+	Prints information regarding the specified database.
 
-	hashesdb hash_is_available hash_name_parameter
+hashesdb stats database_path
+	Prints statistics regarding the specified database.
 
-	hashesdb -u database_path query [-o output_parameter]
+hashesdb hash-functions database_path
+	Prints the hash functions available in the specified database.
 
-	hashesdb -u database_path compare -fuzz fuzzy_hash_function -targets comparsion_targets_file_ids [-all] [-threshold threshold_value] [-o output_parameter]	
+hashesdb hash-is-available hash_function_name database_path
+	Checks if a hash function is available in a specified database
 
-	hashesdb -u database_path print ...
+hashesdb search-duplicates database_path [-f|--file FILE_PATH_PARAM]
+	Searches for files with the same content as the given file
 
-	hashesdb -u database_path find_duplicates --path paths_to_files_parameter
+hashesdb compare fuzzy_hash_function [-t|--targets TARGETS_PARAMETERS]
+									 [[-a|--all]|[-c|--comparsion-targets DIRECTORIES]]
+									 [-r|--recursive]
+									 [-d|--download DOWNLOAD_PATH]
+									 [-l|--limit THRESHOLD_VALUE]
+									 [-o|--output OUTPUT_PARAMETER]
 
-	hashesdb -u database_path find_duplicates --file_id file_ids_parameter
+	Similarity comparsion.
 
-	hashesdb swh -targets scan_targets -calc hash_functions_parameter [-r]
+hashesdb swh ....
+	##TODO###
 
 		
 Commands inside the program's interactive dialog
 --------------------------------------------------
 	help
 		This command will print all the availiable commands.
-
-	help command:
-		This command will print information regarding a specific command.
 
 	version:
 		This command will print the software's version (e.g. hashesdb 1.0.2).
@@ -109,156 +128,41 @@ Commands inside the program's interactive dialog
 	schema
 		This command prints the database schema.
 
-	import import_database_path import_file_path import_file_format [--overwrite]:
-		Import a database from a TXT,CSV,JSON,YAML,XML file.
-		Ask permission for overwriting a database that already exists.
-			Default file_format is CSV. 
+	import import_file_path import_database_path [--overwrite]
+	Imports from a file to a database
 
-	export export_database_path export_file_path file_format [--overwrite]:
-		Export the given database. Supported formats: TXT,CSV,JSON,YAML,XML.
-		Ask permission for overwriting a file that already exists.
-			Default export file name is the name of the database.
-			Default export file directory is the directory in which the database is saved.
-			Default file_format is CSV. 
-			Ask if the user wants to export the changed version or the original version.
+	export export_database_path export_file_path [--overwrite]
+	Exports from a database to a file
 		
-	execute_hdb_scipt hdb_script_path:
-		This command will execute the commands specified by a hdb script located at a given path.
+	scan [-t|--targets TARGETS_PARAMETERS] [-c|--calculate HASH_FUNCTIONS] [-d|--download DOWNLOAD_PATH] [-r|--recursive] [-j|--jobs N]
+	Calculates the hash values of the targets and inserts them in the database
 
-	scan 
-		-targets scan_targets 
-		-calc hash_functions_parameter
-		[-download download_location]
-		[-r]:
-		
-		This command will scan targets, calculate theirs hash keys for specified hash functions and add them to the database.
-		If the optional "recursive" (-r) flag is given, the scan will recursively scan the contents of directories, otherwise it will skip directories.
-			scan_targets can be files, directories, or urls of github/gitlab/bitbucket repos.
-			hash_functions will be a list of hash functions (e.g. (md5,sha1) )
-			If the repos are from the Internet, they will be downloaded to the location specified by the optional parameter download_location. If no location is specified, then the files will be downloaded at the same directory the database is located at.
+	search [--hash HASH_VALUES] [-name|--filename FILENAMES] [-o|--output OUTPUT_PARAMETER]
+	Searches the database for files using one or more criteria.
 
-	hash_functions [-details]:
+	sql sql_query_string [-o|--output OUTPUT_PARAMETER]
+	Executes SQL query
+
+	hash_functions [--details]:
 		This command will print the available hash algorithms.
 		-details flag will print the whole hash_functions table
 
-	hash_is_available hash_name_parameter:
+	hash_is_available hash_function_name:
 		This command will return True if a hash function is available or False otherwise.
 
-	scan_codes
-		This command will print the possible scan codes and their meaning.
+	search-duplicates [-f|--file FILE_PATH_PARAM]
+	Searches for files with the same content as the given file
 
-	query [-o output_parameter]:
-		This command allows the user to type a custom made SELECT query.
-			Optional parameter output_parameter is a path to a file where the results will be printed.
-			Supported formats: TXT,CSV,JSON,YAML,XML.
-			Default output_parameter is the standard output.
+	compare fuzzy_hash_function [-t|--targets TARGETS_PARAMETERS]
+								[[-a|--all]|[-c|--comparsion-targets DIRECTORIES]]
+								[-r|--recursive]
+								[-d|--download DOWNLOAD_PATH]
+								[-l|--limit THRESHOLD_VALUE]
+								[-o|--output OUTPUT_PARAMETER]
 
-	print --scan
-		[-view_scan scan_columns_to_print]
+	Similarity comparsion.
 
-		[-scan_id scan_id_parameter]
-		[-scan_hostname scan_hostname_parameter]
-		[-scan_command_executed scan_command_executed_parameter]
-		[-scan_date scan_date_parameter]
-		[-scan_return_code scan_return_code_parameter]
-
-		[-o output_parameter]
-
-	print --file
-		[-view_file file_columns_to_print]
-		[-view_scan scan_columns_to_print]
-		[-view_swh swh_columns_to_print]
-		[-view_origin origin_columns_to_print]
-
-		[-file_id file_id_parameter]
-		[-scan_id scan_id_parameter]
-		[-file_name file_name_parameter]
-		[-file_extension extension_parameter]
-		[-file_path file_path_parameter]
-		[-swh_known]
-		[-file_updated]
-
-		[-origin_id origin_id_parameter]
-		[-local|-nonlocal]
-		[-origin_url_or_hostname origin_url_or_hostname_parameter]
-		
-		[-o output_parameter]
-
-	print --hash
-		[-view_hash hash_columns_to_print]
-		[-view_hash_function hash_function_columns_to_print]
-		[-view_file file_columns_to_print]
-		[-view_scan scan_columns_to_print]
-		[-view_swh swh_columns_to_print]
-		[-view_origin origin_columns_to_print]
-
-		[-hash_id hash_id_parameter]
-		[-hash_value hash_value_parameter]
-		[-fuzzy]
-		[-hash_function_name hash_functions_parameter]
-
-		[-file_id file_id_parameter]
-		[-scan_id scan_id_parameter]
-		[-file_name file_name_parameter]
-		[-file_extension extension_parameter]
-		[-file_path file_path_parameter]
-		[-swh_known]
-		[-origin_id origin_id_parameter]
-		[-local|-nonlocal]
-		[-origin_url_or_hostname origin_url_or_hostname_parameter]
-		[-file_updated]
-
-		[-o output_parameter]
- 
-	print --swh
-		[-view_swh swh_columns_to_print]
-		[-view_file file_columns_to_print]
-		[-view_scan scan_columns_to_print]
-		[-view_swh swh_columns_to_print]
-		[-view_origin origin_columns_to_print]
-
-		[-swh_id_core swh_id_core_parameter]
-		[-swh_id_qualifiers swh_id_qualifiers_parameter]
-
-		[-file_id file_id_parameter]
-		[-scan_id scan_id_parameter]
-		[-file_name file_name_parameter]
-		[-file_extension extension_parameter]
-		[-file_path file_path_parameter]
-		[-swh_known]
-		[-origin_id origin_id_parameter]
-		[-local|-nonlocal]
-		[-origin_url_or_hostname origin_url_or_hostname_parameter]
-		[-file_updated]
-
-		[-o output_parameter]
-
-	print --origin
-		[-view columns_to_print]
-
-		[-origin_id origin_id_parameter]
-		[-local|-nonlocal]
-		[-origin_url_or_hostname origin_url_or_hostname_parameter]
-
-		[-o output_parameter]
-
-	compare
-		-fuzz fuzzy_hash_function 
-		-targets comparsion_targets_file_ids
-		[-all]
-		[-threshold threshold_value]
-
-		[-o output_parameter]
-
-	find_duplicates --path paths_to_files_parameter
-	find_duplicates --file_id file_ids_parameter
 
 	??
 	swh
-		-targets scan_targets 
-		-calc hash_functions_parameter
-		[-r]:
 	??
-
-/*TODO*/
-Specify "begins with" and "contains" when it comes to "print" command parameters

--- a/docs/project_notes.txt
+++ b/docs/project_notes.txt
@@ -1,0 +1,29 @@
+Change all docstrings to follow numpydoc standard: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard 
+For parser: - https://docs.python.org/3/library/argparse.html + https://realpython.com/command-line-interfaces-python-argparse/
+
+Add \n's to use-unuse-Db.__init__-display_unused_warning-save-rollback
+
+search duplicates for directories?
+search HASH OR FILENAME?
+SQL SELECT only?
+abbreviations?
+importing from TXT is important?
+output_path_parameter = sys.stdout ???
+think if you want the db to be created if it does not exist for subcommands (sql etc) too
+
+https://www.kite.com/python/docs/sqlalchemy.orm.Session.is_modified
+https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.ORMExecuteState
+
+[] Parser
+[] REPL
+[] Import
+[] Export
+[] Scan
+[] Search
+[] SQL Query
+...
+...
+...
+[] UNIT TESTING
+
+verbose/quiet

--- a/src/app.py
+++ b/src/app.py
@@ -1,10 +1,29 @@
-from create import is_valid_db_path, create as create_create
-from os.path import abspath
+from create import is_hashesdb_database, is_valid_db_path, create as create_create
+from os.path import abspath,isfile
 from os import getcwd
 
+from db import Db,NoDb,database_is_used
+
 class App:
-	#Class initialization
+	"""
+	This is the main class of our application. It provides an interface used by the parser.
+	"""
+
 	def __init__(self, used_database_path_param = None):
+		"""
+		Description
+		-----------
+		App class initializer
+
+		Parameters
+		-----------
+		used_database_path_param: string, optional
+			When set, the app starts and immediately tries to use a hashesDB database located at the given path(either relative or absolute path) 
+
+		Results
+		-----------
+		Initializes self.max_threads, self.working_directory and self.used_database.
+		If we use a database when the function ends, self.used_database is a Db() object. Otherwise it is a NoDb() object."""
 
 		#By default our app runs sequentially
 		self.max_threads = 1
@@ -13,37 +32,32 @@ class App:
 		self.working_directory = getcwd()
 
 		if used_database_path_param == None:
-			#If no specific database-to-use is set, set the appropriate flag to False.
-			self.database_used_flag = False
-			self.used_database_path = None
+			#Set used_database to NoDb. NoDb class represents the 'no database' used state.
+			self.used_database = NoDb()
 		else:
-			#If a specific database-to-use is set, try to use it
 			db_absolute_path = abspath(used_database_path_param)
-
 			try:
+				#If a specific database-to-use is set, try to use it
 				self.use(db_absolute_path)
 			except Exception as e:
-				#If you succeeded in using a database, set the appropriate flag to False, and print an error message.
-				self.database_used_flag = False
-				self.used_database_path = None
+				#If you do not succeeded in using a database, then set used_database to NoDb.
+				self.used_database = NoDb()
 				print(e)
-			else:
-				#This will probably be moved to the self.use() method
-				#If you succeeded in using a database, set the appropriate flag to True.
-				self.database_used_flag = True
-				self.used_database_path = db_absolute_path
 
 	def help(self, command_param = None):
 		#help command implementation here...
 		pass
 
 	def version(self):
-		#version command implementation here...
 		pass
 
 	def about(self):
-		"""def about(self):
-		Result: Prints information about the project."""
+		"""
+		Description
+		-----------
+		Implementetion of the 'about' command.
+		Prints information about the project."""
+
 		print("------------------------------------------------------------------------------------------------------------------------------------------")
 		print("""
 		hashesDB is a command line tool that helps users manage a database of hashes of files. It provides several database
@@ -59,46 +73,80 @@ class App:
 		print("------------------------------------------------------------------------------------------------------------------------------------------")
 
 	def exit(self):
-		#exit command implementation here...
-		#__del__ constructor will be called in here
 		pass
 
 	def threads(self,max_threads_number_parameter):
-		"""def threads(self,max_threads_number_parameter):
-		Parameters: max_threads_number_parameter - sets the maximum number of threads that can be used at parallel scanning
+		"""
+		Description
+		-----------
+		Implementetion of the 'threads' command.
+		Sets the maximum number of threads that can be used while parallel scanning.
 
-		Result: The method sets self.max_threads = max_threads_number_parameter
+		Parameters
+		-----------
+		used_database_path_param: int
+			Maximum number of threads
 
-		Errors: Throws an error if the parameter is not an integer or if the parameter is not greater than zero."""
+		Results
+		-----------
+		Checks if the given parameter is an integer > 0 and then changes self.max_threads to max_threads_number_parameter (in the App() class)."""
+
 		try:
+			#Try to convert the given to parameter to an integer
 			max_threads_number = int(max_threads_number_parameter)
 		except (TypeError, ValueError) as e:
+			#If you fail, then the given parameter is not an integer
 			print("Error: max_threads parameter should be an integer.")
 		else:
+			#If you succeed, then check that the parameter is greater than 0
 			if max_threads_number > 0:
 				self.max_threads = max_threads_number
 			else:
 				print("Error: max_threads parameter should be greater than zero.")
 
 	def create(self, path_param, overwrite_flag = False):
-		create_create(path_param, overwrite_flag)
+		"""
+		Description
+		-----------
+		Implementetion of the 'create' command.
+		Creates a new initiliazed hashesDB database by calling the 'create' function from src/create.py. 
+
+		Parameters
+		-----------
+		path_param: string
+			A path(relative or absolute) that specifies where the new database will be located. This has to be a path to a .db file.
+		
+		overwrite_flag - boolean, optional
+			In case a .db file exists at the given path, then if overwrite_flag = True the file will be overwritten.
+			Otherwise an error message will be printed.
+
+		Results
+		-----------
+		Returns True if the database was successfully created. Otherwise it returns False."""
+
+		db_absolute_path = abspath(path_param)
+		return create_create(db_absolute_path, overwrite_flag)
 
 	def use(self, path_param):
-		#use command implementation here...
 		pass
-
+		
 	def unuse(self):
-		#unuse command implementation here...
 		pass
 
 	def status(self):
-		if not self.database_used_flag:
-			#If there is no database currently used:
+		"""
+		Description
+		-----------
+		Implementetion of the 'status' command.
+		Prints information about the current status of the app (used database, unsaved changes, number of threads available for parallization and working directory). """
+
+		if not database_is_used(self.used_database):
+			#If there is no database currently used then inform the user
 			print("No database is currently active. You can choose a database to manage with the 'use database_path' command.\n")
 		else:
 			#If there is a database currently used, check if there are unsaved changes waiting to be commited
-			print(f"Database currently used: {self.used_database_path}\n")
-			if self.unsaved_changes_flag:
+			print(f"Database currently used: {self.used_database.get_database_path()}\n")
+			if self.used_database.has_unsaved_changes():
 				print("There are unsaved changes made regarding this database. You can commit them to the database with the 'save' command.")
 			else:
 				print("There are no unsaved changes made regarding this database.")
@@ -107,7 +155,8 @@ class App:
 		print(f"Number of maximum threads allowed: {self.max_threads}\n")
 
 		#Print maximum threads
-		print(f"Working directory: {self.working_directory}\n")		
+		print(f"Working directory: {self.working_directory}\n")				
+
 
 	def schema(self):
 		#schema command implementation here...
@@ -120,3 +169,43 @@ class App:
 	def export_db(self, export_database_path_param, export_file_path_param, export_file_format_param, overwrite_flag = False):
 		#export command implementation here...
 		pass
+
+	def save(self):
+		"""
+		Description
+		-----------
+		Implementetion of the 'save' command.
+		If a database is used and it has unsaved changes then it saves them. Otherwise it prints a warning message.
+		If we use a database when the function ends, self.used_database is a Db() object. Otherwise it is a NoDb() object."""
+		
+		self.used_database.save()
+
+	def rollback(self):
+		"""
+		Description
+		-----------
+		Implementetion of the 'rollback' command.
+		If a database is used and it has unsaved changes then it cancels them. Otherwise it prints a warning message.
+		If we use a database when the function ends, self.used_database is a Db() object. Otherwise it is a NoDb() object."""
+		
+		self.used_database.rollback()
+
+	def clear(self):
+		"""
+		Description
+		-----------
+		Implementetion of the 'clear' command.
+		If a database is used then it asks for permission to drop all its data. Otherwise it prints a warning message.
+		If we use a database when the function ends, self.used_database is a Db() object. Otherwise it is a NoDb() object."""
+		
+		self.used_database.clear()
+
+	def dbinfo(self):
+		"""
+		Description
+		-----------
+		Implementetion of the 'dbinfo' command.
+		If a database is used then it prints information about this database. Otherwise it prints a warning message.
+		If we use a database when the function ends, self.used_database is a Db() object. Otherwise it is a NoDb() object."""
+
+		self.used_database.dbinfo()

--- a/src/create.py
+++ b/src/create.py
@@ -1,19 +1,35 @@
-from sqlalchemy import create_engine,Table, Column, BigInteger, Integer, Boolean, String, Text, DateTime, MetaData, ForeignKey
-from os.path import split,splitext,abspath,isdir,isfile,basename
+from sqlalchemy import create_engine, inspect
+from os.path import split, splitext, abspath, isdir, isfile, basename
 from os import remove
 
 from initialize_database import initialize_db
+from table_classes import *
 
 def create(database_path_parameter, overwrite_flag = False):
-	"""create(database_path_parameter, overwrite_flag = False)
+	"""
+	Description
+	-----------
 	Creates a hashesDB database located at database_path_parameter, if the given path is a .db file and the directory that contains it exists.
-	If the file already exists, it is overwritten if overwrite_flag = True. Otherwise, an error is printed."""
+	If the file already exists, it is overwritten if overwrite_flag = True. Otherwise, an error is printed.
+
+	Parameters
+	-----------
+	database_path_parameter: string
+		An absolute path that specifies where the new database will be located. This has to be a path to a .db file.
+	
+	overwrite_flag - boolean, optional
+		In case a .db file exists at the given path, then if overwrite_flag = True the file will be overwritten.
+		Otherwise an error message will be printed.
+
+	Results
+	-----------
+	Returns True if the database was created and False otherwise"""
 
 	#Check if the directory exists AND if the file is a .db file.
 	if not is_valid_db_path(database_path_parameter):
 		return False
 
-	#Handle .db file overwriting
+	#Handle .db file overwriting: if overwrite_param = True then delete the existing file, otherwise print an error message
 	if isfile(database_path_parameter):
 		if overwrite_flag:
 			delete_file(database_path_parameter)
@@ -22,15 +38,30 @@ def create(database_path_parameter, overwrite_flag = False):
 			print("Use -overwrite flag to allow overwriting.")
 			return False
 
-	#Create the database
+	#Try to create the database
 	try:
 		create_database(database_path_parameter)
 	except RuntimeError as e:
 		print(e)
+		return False
+	
+	return True
 
 
 def is_valid_db_path(database_path_parameter):
-	"""is_valid_db_path(database_path_parameter):
+	"""
+	Description
+	-----------
+	Checks that a given path refers to a file with a .db extension located an existing directory.
+	The directory must exist but the .db file may not exist.
+
+	Parameters
+	-----------
+	database_path_parameter: string
+		A path(relative or absolute) that specifies where the new database will be located. This has to be a path to a .db file.
+
+	Results
+	-----------
 	Returns True if database_path_parameter is a .db file located in an existing directory. Otherwise it returns False."""
 	
 	#Convert parameter to absolute path, in case it is a relative path.
@@ -52,11 +83,21 @@ def is_valid_db_path(database_path_parameter):
 	return True
 		
 def delete_file(database_path_parameter):
-	"""delete_file(database_path_parameter):
-	Deletes a .db database file located at database_path_parameter. Raises error if the directory/file does not exist."""
+	"""
+	Description
+	-----------
+	Deletes a .db database file located at database_path_parameter. 
+	Prints an error message if the path refers to a directory or a non-existing file
 
+	Parameters
+	-----------
+	database_path_parameter: string
+		A path(relative or absolute) that specifies where the new database will be located. This has to be a path to a .db file."""
+	
 	#Convert the path to absolute path in case it is relative path.
 	database_path = abspath(database_path_parameter)
+	
+	#Try to remove the file
 	try:
 		remove(database_path)
 	except IsADirectoryError:
@@ -67,9 +108,20 @@ def delete_file(database_path_parameter):
 		print(f"An unexpected error occured while deleting file {database_path}.")
 
 def create_database(database_path_parameter):
-	"""create_database(database_path_parameter):
-	Creates a hashesDB database located at database_path_parameter.
-	If a file already exists at the given path, an exception is raised."""
+	"""
+	Description
+	-----------
+	Compares the schema of a database with the expected schema of a hashesDB database, in order to find out if a database is a hashesDB database.
+
+	Parameters
+	-----------
+	database_path_parameter: string
+		An absolute path that specifies where the new database will be located. This has to be a path to a .db file.
+
+	Raises
+	-----------
+	Raises a RuntimeError if the database we try to create already exists, since overwriting should be handled before calling this function
+	Raises a RuntimeError if the creation of the database fails."""
 
 	#Check if a file already exists at the given path.
 	if isfile(database_path_parameter):
@@ -77,89 +129,10 @@ def create_database(database_path_parameter):
 
 	engine_url = "sqlite:///" + database_path_parameter
 
-	#Create a database. The .db file will be automatically created after the first query execution
-	#After the creation the DB_INFORMATION, SCAN_CODE and HASH_FUNCTION tables will be initialized
+	#Create a database. The .db file will be automatically created after the execution of engine.connect() 
+	#After the creation, the DB_INFORMATION, SCAN_CODE and HASH_FUNCTION tables will be initialized by initialize_db
 	engine = create_engine(engine_url, echo = False)
 	with engine.connect() as conn:
-		meta = create_tables(engine, conn)
-		initialize_db(meta, conn, database_path_parameter)
-
-def create_tables(engine, conn):
-	"""create_tables(engine):
-	Creates the tables specified by the database schema and sets datatypes, primary keys and foreign keys.
-	Returns the Metadata() object that contains the schema info"""
-
-	meta = MetaData()
-
-	#Define the tables included in the schema
-	db_information = Table(
-		'DB_INFORMATION', meta,
-		Column('db_name', String, primary_key = True),
-		Column('db_date_created', DateTime),
-		Column('db_date_modified', DateTime),
-		Column('db_version', Integer),
-		Column('db_last_scan_id', Integer)
-		)
-
-	scan_code = Table(
-		'SCAN_CODE', meta,
-		Column('scan_return_code', Integer, primary_key = True),
-		Column('scan_return_code_description', Integer)
-		)
-
-	scan = Table(
-		'SCAN', meta,
-		Column('scan_id', Integer, primary_key = True),
-		Column('scan_hostname', String),
-		Column('scan_command_executed', Text),
-		Column('scan_date', DateTime),
-		Column('scan_return_code', Integer, ForeignKey('SCAN_CODE.scan_return_code'))
-		)
-
-	file = Table(
-		'FILE', meta,
-		Column('file_id', Integer, primary_key = True),
-		Column('scan_id', Integer, ForeignKey('SCAN.scan_id')),
-		Column('file_name', String),
-		Column('file_extension', String),
-		Column('file_path', String),
-		Column('file_size', BigInteger),
-		Column('file_date_created', DateTime),
-		Column('file_date_modified', DateTime),
-		Column('swh_known', Boolean),
-		Column('file_updated', Boolean),
-		Column('origin_id', Integer, ForeignKey('ORIGIN.origin_id'))
-		)
-
-	origin = Table(
-		'ORIGIN', meta,
-		Column('origin_id', Integer, primary_key = True),
-		Column('origin_is_local_flag', Boolean),
-		Column('origin_url_or_hostname', String)
-		)
-
-	hash = Table(
-		'HASH', meta,
-		Column('hash_id', Integer, primary_key = True),
-		Column('hash_value', String),
-		Column('hash_function_name', String, ForeignKey('HASH_FUNCTION.hash_function_name')),
-		Column('file_id', Integer, ForeignKey('FILE.file_id'))
-		)
-
-	hash_function = Table(
-		'HASH_FUNCTION', meta,
-		Column('hash_function_name', String, primary_key = True),
-		Column('hash_function_fuzzy_flag', Boolean),
-		Column('hash_function_size', Integer)
-		)
-
-	swh_info = Table(
-		'SWH_INFO', meta,
-		Column('file_id', Integer, ForeignKey('FILE.file_id')),
-		Column('swh_id_core', Integer),
-		Column('swh_id_qualifiers', Integer)
-		)
-
-	#Create the tables
-	meta.create_all(engine)
-	return meta
+		#Try to create the tables and to initialize them
+		Base.metadata.create_all(engine)
+		initialize_db(engine, database_path_parameter)

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,183 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from os.path import abspath
+
+from initialize_database import initialize_db_information
+from table_classes import *
+
+Session = sessionmaker()
+
+class Db:
+	"""Db object is a object that represents a database we are currently using. It provides an interface to the App class, from which the App class can make changes to the database."""
+
+
+	def __init__(self, used_database_path_param):
+		"""
+		Description
+		-----------
+		Initializes a Db() object.
+		In more detail:
+			-self.unsaved_changes_flag is a boolean: True if there unsaved changes in the datafase and False otherwise.
+			-self.database_path is a string: the absolute path that leads to the database currently used
+			-self.db_session is a SQLAlchemyORM session: the active session we use to make changes to the database
+
+		Parameters
+		-----------
+		used_database_path_param: string
+			A path(relative or absolute) that specifies where the database we intend to use is located. This has to be a path to a .db file.
+		
+		Raises
+		-----------
+		Raises an exception if we fail to begin a session."""
+
+		#When the database session begins, no changes have been made
+		self.unsaved_changes_flag = False
+		self.database_path = abspath(used_database_path_param)
+
+		#Create an engine and configure a session
+		engine_url = "sqlite:///" + self.database_path
+		engine = create_engine(engine_url, echo = False)
+		Session.configure(bind=engine)
+
+		#Try begin a session
+		try:
+			self.db_session = Session()
+			self.db_session.begin()
+		except Exception as e:
+			raise e
+		else:
+			print(f"Database currently used: {self.get_database_path()}\n")
+
+	def __del__(self):
+		"""
+		Description
+		-----------
+		Destroys a Db() object. It closes the active session.
+
+		Raises
+		-----------
+		Raises an exception if we fail to close a session."""
+
+		try:
+			self.db_session.close()
+		except Exception as e:
+			raise Exception("Error: a problem occured while trying to disconnect from the database.")
+
+	def get_database_path(self):
+		"""
+		Description
+		-----------
+		Returns the absolute path that leads to the database currently used """
+
+		return self.database_path
+
+	def has_unsaved_changes(self):
+		"""
+		Description
+		-----------
+		Should return True if there unsaved changes in the datafase and False otherwise."""
+
+		return self.unsaved_changes_flag
+
+	def save(self):
+		pass
+
+	def rollback(self):
+		pass
+
+	def clear(self):
+		pass
+
+	def dbinfo(self):
+		pass
+
+class NoDb:
+	"""NoDb object is a object that provides the same interface as the Db object. It is used when we do NOT use a database in our application."""
+
+	def __init__(self):
+		"""
+		Description
+		-----------
+		Initializes a Db() object.
+		In more detail:
+			-self.unused_database_message is a string: a message that will be displayed if the user attempts to use a method that can only be applied to a Db() object.
+			-self.database_path is a string: None"""
+
+		self.unused_database_message = "Error: You have to select a database to use before running this command. You can choose a database to use with the 'use' command\n"
+		self.database_path = None
+
+	def display_unused_warning(self):
+		"""
+		Description
+		-----------
+		Prints an error message informing us that the method we try to use applies only to Db() object."""
+
+		print(self.unused_database_message)
+
+	def get_database_path(self):
+		"""
+		Description
+		-----------
+		Returns the absolute path that leads to the database currently used."""
+
+		return self.database_path
+
+	def has_unsaved_changes(self):
+		"""
+		Description
+		-----------
+		This method refer to commands that can only be applied when a database is used, so they print a relative warning message."""
+
+		self.display_unused_warning()
+
+	def save(self):
+		"""
+		Description
+		-----------
+		This method refer to commands that can only be applied when a database is used, so they print a relative warning message."""		
+
+		self.display_unused_warning()
+
+	def rollback(self):
+		"""
+		Description
+		-----------
+		This method refer to commands that can only be applied when a database is used, so they print a relative warning message."""	
+
+		self.display_unused_warning()
+
+	def clear(self):
+		"""
+		Description
+		-----------
+		This method refer to commands that can only be applied when a database is used, so they print a relative warning message."""
+
+		self.display_unused_warning()
+
+	def dbinfo(self):
+		"""
+		Description
+		-----------
+		This method refer to commands that can only be applied when a database is used, so they print a relative warning message."""
+
+		self.display_unused_warning()
+
+def database_is_used(database_object):
+	"""
+	Description
+	-----------
+	Checks if a we currently use a database by checking the type of the database_object
+
+	Parameters
+	-----------
+	database_is_used:
+		An object (usually either a Db() object or a NoDb() object)
+
+	Results
+	-----------
+	Returns True if the given object has type 'Db'. Otherwise it returns False."""
+	
+	if type(database_object).__name__ == 'Db':
+		return True
+	else:
+		return False

--- a/src/table_classes.py
+++ b/src/table_classes.py
@@ -1,0 +1,67 @@
+from sqlalchemy import Column, BigInteger, Integer, Boolean, String, Text, DateTime, ForeignKey
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+"""The following classes declare the tables of a database"""
+
+class DbInformation(Base):
+   __tablename__ = 'DB_INFORMATION'
+   db_name = Column(String, primary_key = True)
+   db_date_created = Column(DateTime)
+   db_date_modified = Column(DateTime)
+   db_version = Column(Integer)
+   db_last_scan_id = Column(Integer)
+
+class ScanCode(Base):
+   __tablename__ = 'SCAN_CODE'
+   scan_return_code = Column(Integer, primary_key = True)
+   scan_return_code_description = Column(Integer)
+
+class Scan(Base):
+   __tablename__ = 'SCAN'
+   scan_id = Column(Integer, primary_key = True)
+   scan_hostname = Column(String)
+   scan_command_executed = Column(Text)
+   scan_date = Column(DateTime)
+   scan_return_code = Column(Integer, ForeignKey('SCAN_CODE.scan_return_code'))
+
+class Origin(Base):
+   __tablename__ = 'ORIGIN'
+   origin_id = Column(Integer, primary_key = True)
+   origin_is_local_flag = Column(Boolean)
+   origin_url_or_hostname = Column(String)
+
+class File(Base):
+   __tablename__ = 'FILE'
+   file_id = Column(Integer, primary_key = True)
+   scan_id = Column(Integer, ForeignKey('SCAN.scan_id'))
+   file_name = Column(String)
+   file_extension = Column(String)
+   file_path = Column(String)
+   file_size = Column(BigInteger)
+   file_date_created = Column(DateTime)
+   file_date_modified = Column(DateTime)
+   swh_known = Column(Boolean)
+   file_updated = Column(Boolean)
+   origin_id = Column(Integer, ForeignKey('ORIGIN.origin_id'))
+
+class Hash(Base):
+   __tablename__ = 'HASH'
+   hash_id = Column(Integer, primary_key = True)
+   hash_value = Column(String)
+   hash_function_name = Column(String, ForeignKey('HASH_FUNCTION.hash_function_name'))
+   file_id = Column(Integer, ForeignKey('FILE.file_id'))
+
+class HashFunction(Base):
+   __tablename__ = 'HASH_FUNCTION'
+   hash_function_name = Column(String, primary_key = True)
+   hash_function_fuzzy_flag = Column(Boolean)
+   hash_function_size = Column(Integer)
+
+
+class SwhInfo(Base):
+   __tablename__ = 'SWH_INFO'
+   file_id = Column(Integer, ForeignKey('FILE.file_id'), primary_key = True)
+   swh_id_core = Column(Integer)
+   swh_id_qualifiers = Column(Integer)


### PR DESCRIPTION
This pull request includes a new `docs/commands_draft.txt` file that describes the final command set.

Fixes #3,  fixes #4, fixes #37, fixes #65.

Also closes #38 and closes #28  by deciding against the inclusion of such commands.
(#28 refered to a command that would allow the user to write a script consisting of REPL commands. Since standalone commands will include all the available functionalities, there is no reason for such the execute-hdb-script command to exist.)

(The first 5 commits are identical to #49 .)